### PR TITLE
Remove alias config

### DIFF
--- a/v3/internal/templates/vanilla-ts/frontend/src/main.ts.tmpl
+++ b/v3/internal/templates/vanilla-ts/frontend/src/main.ts.tmpl
@@ -1,5 +1,5 @@
-import {GreetService} from "@bindings/{{ js (or .Git "changeme") }}";
 import {Events} from "@wailsio/runtime";
+import {GreetService} from "../bindings/{{ js (or .Git "changeme") }}";
 
 const greetButton = document.getElementById('greet')! as HTMLButtonElement;
 const resultElement = document.getElementById('result')! as HTMLDivElement;

--- a/v3/internal/templates/vanilla-ts/frontend/tsconfig.json
+++ b/v3/internal/templates/vanilla-ts/frontend/tsconfig.json
@@ -28,10 +28,6 @@
     "noUnusedParameters": false,
     "noImplicitAny": false,
     "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true,
-
-    "paths": {
-      "@bindings/*": ["./bindings/*"]
-    }
+    "noFallthroughCasesInSwitch": true
   }
 }

--- a/v3/internal/templates/vanilla-ts/frontend/vite.config.js
+++ b/v3/internal/templates/vanilla-ts/frontend/vite.config.js
@@ -1,4 +1,3 @@
-import { fileURLToPath, URL } from "url";
 import { defineConfig } from "vite";
 import wailsTypedEventsPlugin from "@wailsio/runtime/plugins/vite";
 
@@ -8,9 +7,4 @@ export default defineConfig({
   build: {
     target: "safari11"
   },
-  resolve: {
-    alias: [
-      { find: "@bindings", replacement: fileURLToPath(new URL("bindings", import.meta.url)) },
-    ]
-  }
 })

--- a/v3/internal/templates/vanilla/frontend/src/main.js.tmpl
+++ b/v3/internal/templates/vanilla/frontend/src/main.js.tmpl
@@ -1,5 +1,5 @@
-import {GreetService} from "@bindings/{{ js (or .Git "changeme") }}";
 import {Events} from "@wailsio/runtime";
+import {GreetService} from "../bindings/{{ js (or .Git "changeme") }}";
 
 const resultElement = document.getElementById('result');
 const timeElement = document.getElementById('time');

--- a/v3/internal/templates/vanilla/frontend/tsconfig.json
+++ b/v3/internal/templates/vanilla/frontend/tsconfig.json
@@ -29,9 +29,5 @@
     "noImplicitAny": false,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-
-    "paths": {
-      "@bindings/*": ["./bindings/*"]
-    }
   }
 }

--- a/v3/internal/templates/vanilla/frontend/vite.config.js
+++ b/v3/internal/templates/vanilla/frontend/vite.config.js
@@ -1,4 +1,3 @@
-import { fileURLToPath, URL } from "url";
 import { defineConfig } from "vite";
 import wailsTypedEventsPlugin from "@wailsio/runtime/plugins/vite";
 
@@ -8,9 +7,4 @@ export default defineConfig({
   build: {
     target: "safari11"
   },
-  resolve: {
-    alias: [
-      { find: "@bindings", replacement: fileURLToPath(new URL("bindings", import.meta.url)) },
-    ]
-  }
-})
+});


### PR DESCRIPTION
It's not really needed here anymore, and folks can set up whatever aliasing scheme they like (vite, subpath imports, etc).
