### PR TITLE
Provide path to bindings for plugin

### DIFF
--- a/v3/internal/templates/vanilla-ts/frontend/vite.config.js
+++ b/v3/internal/templates/vanilla-ts/frontend/vite.config.js
@@ -4,7 +4,7 @@ import wailsTypedEventsPlugin from "@wailsio/runtime/plugins/vite";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [wailsTypedEventsPlugin()],
+  plugins: [wailsTypedEventsPlugin("./bindings")],
   build: {
     target: "safari11"
   },

--- a/v3/internal/templates/vanilla/frontend/vite.config.js
+++ b/v3/internal/templates/vanilla/frontend/vite.config.js
@@ -4,7 +4,7 @@ import wailsTypedEventsPlugin from "@wailsio/runtime/plugins/vite";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [wailsTypedEventsPlugin()],
+  plugins: [wailsTypedEventsPlugin("./bindings")],
   build: {
     target: "safari11"
   },


### PR DESCRIPTION
This is now a required parameter to the plugin, and allows us to avoid using an alias (#7).