### PR TITLE
Update lit template

### DIFF
--- a/v3/internal/commands/build_assets/Taskfile.tmpl.yml
+++ b/v3/internal/commands/build_assets/Taskfile.tmpl.yml
@@ -76,6 +76,10 @@ tasks:
     dir: frontend
     deps:
       - task: install:frontend:deps
+      - task: generate:bindings
+        vars:
+          BUILD_FLAGS:
+            ref: .BUILD_FLAGS
     cmds:
       - npm run dev -- --port {{ "{{.VITE_PORT}}" }} --strictPort
 

--- a/v3/internal/templates/_common/main.go.tmpl
+++ b/v3/internal/templates/_common/main.go.tmpl
@@ -18,6 +18,9 @@ import (
 var assets embed.FS
 
 func init() {
+	// Register a custom event whose associated data type is string.
+	// This is not required, but the binding generator will pick up registered events
+	// and provide a strongly typed JS/TS API for them.
 	application.RegisterEvent[string]("time")
 }
 

--- a/v3/internal/templates/_common/main.go.tmpl
+++ b/v3/internal/templates/_common/main.go.tmpl
@@ -17,6 +17,10 @@ import (
 //go:embed all:frontend/dist
 var assets embed.FS
 
+func init() {
+	application.RegisterEvent[string]("time")
+}
+
 // main function serves as the application's entry point. It initializes the application, creates a window,
 // and starts a goroutine that emits a time-based event every second. It subsequently runs the application and
 // logs any error that might occur.

--- a/v3/internal/templates/lit/frontend/package.json.tmpl
+++ b/v3/internal/templates/lit/frontend/package.json.tmpl
@@ -14,6 +14,6 @@
   },
   "devDependencies": {
     "vite": "^5.0.0",
-    "@wailsio/runtime": "latest"
+    "@wailsio/runtime": "{{if .LocalModulePath}}file:../{{.LocalModulePath}}v3/internal/runtime/desktop/@wailsio/runtime{{else}}latest{{end}}"
   }
 }

--- a/v3/internal/templates/lit/frontend/tsconfig.json
+++ b/v3/internal/templates/lit/frontend/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "include": [
+    "./src/**/*",
+    "./bindings/github.com/wailsapp/wails/v3/internal/eventdata.d.ts"
+  ],
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": false,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "module": "ES2020",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "lib": [
+      "DOM",
+      "DOM.Iterable",
+      "ESNext",
+    ],
+    "strict": false,
+  }
+}

--- a/v3/internal/templates/lit/frontend/vite.config.js
+++ b/v3/internal/templates/lit/frontend/vite.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from "vite";
+import wailsTypedEventsPlugin from "@wailsio/runtime/plugins/vite";
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [wailsTypedEventsPlugin("./bindings")],
+})


### PR DESCRIPTION
This does three main things:

- Fixes a race which was causing vite to start up before bindings finished generating, throwing an error in the new plugin.
- Adds `application.RegisterEvent[string]("time")` to the `main.go` template
- Updates the js lit template:
	- changes package.json to use the dev runtime package if possible
	- adds a basic `tsconfig.json` for javascript (pretty lax, doesn't really check anything
	- adds a vite config to inject the plugin.  

I kept the vite config and tsconfig very un-opinionated for the time being.  I figure it's easiest to start here, and add to it as needed/desired.