### PR TITLE
Switch to tsconfig.json for jetbrains IDE support

### DIFF
--- a/v3/examples/dev/frontend/tsconfig.json
+++ b/v3/examples/dev/frontend/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "allowJs": true,
     "moduleResolution": "Node",
     "target": "ESNext",
     "module": "ESNext",

--- a/v3/internal/templates/lit/frontend/tsconfig.json
+++ b/v3/internal/templates/lit/frontend/tsconfig.json
@@ -1,11 +1,10 @@
 /** 
  * This file tells your IDE where the root of your JavaScript project is, and sets some
  * options that it can use to provide autocompletion and other features.  
- * 
- * List of options: https://code.visualstudio.com/docs/languages/jsconfig#_jsconfig-options
  */
 {
   "compilerOptions": {
+    "allowJs": true,
     "moduleResolution": "bundler",
     /**
      * The target and module can be set to ESNext to allow writing modern JavaScript, 
@@ -16,11 +15,11 @@
     "module": "ESNext",
     "resolveJsonModule": true,
     /**
-     * Enable checkJs if you'd like type checking in `.svelte` and `.js` files.
+     * Enable checkJs if you'd like type checking in `.js` files.
      */
     "checkJs": false,
     "strict": true,
     "skipLibCheck": true,
   },
-  "include": ["src/**/*.d.ts", "src/**/*.js", "src/**/*.svelte", "bindings/**/*.d.ts"]
+  "include": ["src", "bindings"]
 }

--- a/v3/internal/templates/preact/frontend/tsconfig.json
+++ b/v3/internal/templates/preact/frontend/tsconfig.json
@@ -1,11 +1,10 @@
 /** 
  * This file tells your IDE where the root of your JavaScript project is, and sets some
  * options that it can use to provide autocompletion and other features.  
- * 
- * List of options: https://code.visualstudio.com/docs/languages/jsconfig#_jsconfig-options
  */
 {
   "compilerOptions": {
+    "allowJs": true,
     "moduleResolution": "bundler",
     /**
      * The target and module can be set to ESNext to allow writing modern JavaScript, 
@@ -16,7 +15,7 @@
     "module": "ESNext",
     "resolveJsonModule": true,
     /**
-     * Enable checkJs if you'd like type checking in `.js` files.
+     * Enable checkJs if you'd like type checking in `.js(x)` files.
      */
     "checkJs": false,
     "strict": true,

--- a/v3/internal/templates/qwik/frontend/tsconfig.json
+++ b/v3/internal/templates/qwik/frontend/tsconfig.json
@@ -1,11 +1,10 @@
 /** 
  * This file tells your IDE where the root of your JavaScript project is, and sets some
  * options that it can use to provide autocompletion and other features.  
- * 
- * List of options: https://code.visualstudio.com/docs/languages/jsconfig#_jsconfig-options
  */
 {
   "compilerOptions": {
+    "allowJs": true,
     "moduleResolution": "bundler",
     /**
      * The target and module can be set to ESNext to allow writing modern JavaScript, 
@@ -16,7 +15,7 @@
     "module": "ESNext",
     "resolveJsonModule": true,
     /**
-     * Enable checkJs if you'd like type checking in `.js` files.
+     * Enable checkJs if you'd like type checking in `.js(x)` files.
      */
     "checkJs": false,
     "strict": true,

--- a/v3/internal/templates/react-swc/frontend/tsconfig.json
+++ b/v3/internal/templates/react-swc/frontend/tsconfig.json
@@ -1,11 +1,10 @@
 /** 
  * This file tells your IDE where the root of your JavaScript project is, and sets some
  * options that it can use to provide autocompletion and other features.  
- * 
- * List of options: https://code.visualstudio.com/docs/languages/jsconfig#_jsconfig-options
  */
 {
   "compilerOptions": {
+    "allowJs": true,
     "moduleResolution": "bundler",
     /**
      * The target and module can be set to ESNext to allow writing modern JavaScript, 
@@ -16,11 +15,11 @@
     "module": "ESNext",
     "resolveJsonModule": true,
     /**
-     * Enable checkJs if you'd like type checking in `.svelte` and `.js` files.
+     * Enable checkJs if you'd like type checking in `.js(x)` files.
      */
     "checkJs": false,
     "strict": true,
     "skipLibCheck": true,
   },
-  "include": ["src/**/*.d.ts", "src/**/*.js", "src/**/*.svelte", "bindings"]
+  "include": ["src", "bindings"]
 }

--- a/v3/internal/templates/react/frontend/tsconfig.json
+++ b/v3/internal/templates/react/frontend/tsconfig.json
@@ -1,11 +1,10 @@
 /** 
  * This file tells your IDE where the root of your JavaScript project is, and sets some
  * options that it can use to provide autocompletion and other features.  
- * 
- * List of options: https://code.visualstudio.com/docs/languages/jsconfig#_jsconfig-options
  */
 {
   "compilerOptions": {
+    "allowJs": true,
     "moduleResolution": "bundler",
     /**
      * The target and module can be set to ESNext to allow writing modern JavaScript, 

--- a/v3/internal/templates/solid/frontend/tsconfig.json
+++ b/v3/internal/templates/solid/frontend/tsconfig.json
@@ -1,11 +1,10 @@
 /** 
  * This file tells your IDE where the root of your JavaScript project is, and sets some
  * options that it can use to provide autocompletion and other features.  
- * 
- * List of options: https://code.visualstudio.com/docs/languages/jsconfig#_jsconfig-options
  */
 {
   "compilerOptions": {
+    "allowJs": true,
     "moduleResolution": "bundler",
     /**
      * The target and module can be set to ESNext to allow writing modern JavaScript, 

--- a/v3/internal/templates/svelte/frontend/tsconfig.json
+++ b/v3/internal/templates/svelte/frontend/tsconfig.json
@@ -1,11 +1,10 @@
 /** 
  * This file tells your IDE where the root of your JavaScript project is, and sets some
  * options that it can use to provide autocompletion and other features.  
- * 
- * List of options: https://code.visualstudio.com/docs/languages/jsconfig#_jsconfig-options
  */
 {
   "compilerOptions": {
+    "allowJs": true,
     "moduleResolution": "bundler",
     /**
      * The target and module can be set to ESNext to allow writing modern JavaScript, 
@@ -16,11 +15,11 @@
     "module": "ESNext",
     "resolveJsonModule": true,
     /**
-     * Enable checkJs if you'd like type checking in `.js(x)` files.
+     * Enable checkJs if you'd like type checking in `.svelte` and `.js` files.
      */
     "checkJs": false,
     "strict": true,
     "skipLibCheck": true,
   },
-  "include": ["src", "bindings"]
+  "include": ["src/**/*.d.ts", "src/**/*.js", "src/**/*.svelte", "bindings"]
 }

--- a/v3/internal/templates/sveltekit/frontend/package.json
+++ b/v3/internal/templates/sveltekit/frontend/package.json
@@ -7,8 +7,8 @@
 		"build:dev": "vite build --minify false --mode development",
 		"build": "vite build --mode production",
 		"preview": "vite preview",
-		"check": "svelte-kit sync && svelte-check --tsconfig ./jsconfig.json",
-		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./jsconfig.json --watch"
+		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
+		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch"
 	},
 	"devDependencies": {
 		"@sveltejs/adapter-auto": "^3.0.0",

--- a/v3/internal/templates/sveltekit/frontend/tsconfig.json
+++ b/v3/internal/templates/sveltekit/frontend/tsconfig.json
@@ -1,11 +1,10 @@
 /** 
  * This file tells your IDE where the root of your JavaScript project is, and sets some
  * options that it can use to provide autocompletion and other features.  
- * 
- * List of options: https://code.visualstudio.com/docs/languages/jsconfig#_jsconfig-options
  */
 {
   "compilerOptions": {
+    "allowJs": true,
     "moduleResolution": "bundler",
     /**
      * The target and module can be set to ESNext to allow writing modern JavaScript, 
@@ -16,11 +15,11 @@
     "module": "ESNext",
     "resolveJsonModule": true,
     /**
-     * Enable checkJs if you'd like type checking in `.js(x)` files.
+     * Enable checkJs if you'd like type checking in `.svelte` and `.js` files.
      */
     "checkJs": false,
     "strict": true,
     "skipLibCheck": true,
   },
-  "include": ["src", "bindings"]
+  "include": ["src/**/*.d.ts", "src/**/*.js", "src/**/*.svelte", "bindings/**/*.d.ts"]
 }

--- a/v3/internal/templates/vanilla/frontend/tsconfig.json
+++ b/v3/internal/templates/vanilla/frontend/tsconfig.json
@@ -1,11 +1,10 @@
 /** 
  * This file tells your IDE where the root of your JavaScript project is, and sets some
  * options that it can use to provide autocompletion and other features.  
- * 
- * List of options: https://code.visualstudio.com/docs/languages/jsconfig#_jsconfig-options
  */
 {
   "compilerOptions": {
+    "allowJs": true,
     "moduleResolution": "bundler",
     /**
      * The target and module can be set to ESNext to allow writing modern JavaScript, 
@@ -16,11 +15,11 @@
     "module": "ESNext",
     "resolveJsonModule": true,
     /**
-     * Enable checkJs if you'd like type checking in `.vue` and `.js` files.
+     * Enable checkJs if you'd like type checking in `.js` files.
      */
     "checkJs": false,
     "strict": true,
     "skipLibCheck": true,
   },
-  "include": ["src/**/*.d.ts", "src/**/*.js", "src/**/*.jsx", "src/**/*.vue", "bindings"]
+  "include": ["src", "bindings"]
 }

--- a/v3/internal/templates/vue/frontend/tsconfig.json
+++ b/v3/internal/templates/vue/frontend/tsconfig.json
@@ -1,11 +1,10 @@
 /** 
  * This file tells your IDE where the root of your JavaScript project is, and sets some
  * options that it can use to provide autocompletion and other features.  
- * 
- * List of options: https://code.visualstudio.com/docs/languages/jsconfig#_jsconfig-options
  */
 {
   "compilerOptions": {
+    "allowJs": true,
     "moduleResolution": "bundler",
     /**
      * The target and module can be set to ESNext to allow writing modern JavaScript, 
@@ -16,11 +15,11 @@
     "module": "ESNext",
     "resolveJsonModule": true,
     /**
-     * Enable checkJs if you'd like type checking in `.js(x)` files.
+     * Enable checkJs if you'd like type checking in `.vue` and `.js` files.
      */
     "checkJs": false,
     "strict": true,
     "skipLibCheck": true,
   },
-  "include": ["src", "bindings"]
+  "include": ["src/**/*.d.ts", "src/**/*.js", "src/**/*.jsx", "src/**/*.vue", "bindings"]
 }


### PR DESCRIPTION
This is equivalent to the jsconfig we had before (jsconfig extends from tsconfig, and sets `allowJs: true`.

Reason for change:

> First, it does not accept the extended json syntax w/ comments; second, it seems it won't pick up global .d.ts files unless there is a tsconfig (not even with an explicit include)